### PR TITLE
feat: Add SandBase CLI to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Use these hashtags in search to filter out the tools
 - [Respan](https://www.respan.ai/ai-gateway) - Full-stack AI engineering platform for tracing, evals, prompt management, and a gateway to 250+ models. `#freemium`
 - [ReviewCerberus](https://github.com/Kirill89/reviewcerberus) - 100% free, open-source AI code review tool for analyzing git branch differences with comprehensive security, performance, and quality analysis. `#free`
 - [Safurai](https://www.safurai.com/) - The AI Code Assistant that really helps developers. `#free`
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source CLI and MCP bridge for OpenAI-compatible access to 2,000+ AI models through usage-based pricing and a free plan. `#freemium` `#opensource`
 - [Sizzle AI](https://web.szl.ai/) - AI-powered tutor for math and coding problems. `#free`
 - [Solo](https://soloist.ai/) - Free AI website creation and domain hosting. `#free`
 - [Sourcegraph Cody](https://sourcegraph.com/cody) - AI coding assistant with deep codebase context, for VS Code, JetBrains and web. `#freemium`


### PR DESCRIPTION
## What
- Add SandBase CLI to the Developer Tools section
- Link the canonical repository and describe its open-source CLI/MCP bridge

## Why
SandBase CLI provides OpenAI-compatible access to 2,000+ AI models and supports MCP clients. This is a focused documentation-only addition following the repository contribution format.

- Project: https://github.com/sandbaseai/cli
- Docs: https://docs.sandbase.ai
- Pricing: usage-based with a free plan

The project is maintained by the submitting organization; disclosed for transparency.