### PR TITLE
feat: Add H3 Max Studio to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,7 @@ Use these hashtags in search to filter out the tools
 - [Flow Studio](https://flowstudio.ai/) - Chat characters, robots, and prompt management. `#free`
 - [Gemini Omni AI](https://geminiomni.co/) - Craft cinematic AI videos with Gemini Omni, the unified omni-model — generate, edit, and remix clips in native 4K with built-in audio and Director's Mode. `#freemium`
 - [Google Vids](https://workspace.google.com/products/vids/) - Integrated Workspace creation and scripts. `#paid`
+- [H3 Max Studio](https://minimaxh3-max.org/) - Independent web app for text-to-video and image-to-video generation with MiniMax H3 Max through fal. `#paid`
 - [Hedra](https://hedra.com/) - Multimodal personal AI creation studio. `#free`
 - [Heygen](https://www.heygen.com/) - Create videos from text in minutes with AI-generated avatars and voices. `#freemium`
 - [HeyVid](https://heyvid.ai/) - An all-in-one AI video and image generator. `#freemium`


### PR DESCRIPTION
## Description

Adds H3 Max Studio to the Video category in alphabetical order, between Google Vids and Hedra.

Submitting on behalf of the site owner. H3 Max Studio is an independent paid web app using MiniMax H3 Max through fal for text-to-video and image-to-video generation. It is not an official MiniMax, Hailuo, or fal product and has no free generation quota.

Product: https://minimaxh3-max.org/
Pricing: https://minimaxh3-max.org/pricing/

## Type of Change

- [x] Tool Submission

## Checklist

- [x] Read the contributing guidelines and code of conduct.
- [x] Checked that the tool is not already listed or proposed in an open PR.
- [x] Used the direct product URL, a factual description, and the `#paid` tag.
- [x] Added one entry alphabetically within the Video category.
- [x] Reviewed the diff: README.md only, one addition, no deletions.

## Validation

Checked the public homepage, usage guides, and pricing information. No paid video-generation job was run for this submission. This is a documentation-only change; application code is unchanged.
