### PR TITLE
feat: Add ParlayAPI MCP to Data & BI

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Use these hashtags in search to filter out the tools
 - [Formula bot](https://formulabot.com/) - Instant formula generation without registration. `#free`
 - [FormX.ai](https://formx.ai/) - Automated data extraction from invoices/contracts. `#free`
 - [GPTExcel](https://gptexcel.uk/) - Effortlessly create and understand formulas in Excel and Google Sheets! `#paid`
+- [ParlayAPI MCP](https://github.com/JacobiusMakes/parlay-api-mcp) - Connects AI assistants to sports odds, player props, public event discovery, and account usage; account data tools use each user's own API key and allowances. `#mcp` `#freemium`
 - [Parseur](https://parseur.com/) - Parseur is a powerful data entry software that automates text extraction from emails, PDFs, and other documents, enhancing productivity by eliminating manual data entry. `#freemium`
 - [Rows](https://rows.com/) - Redefined spreadsheet for team data analysis. `#free`
 - [SheetAI.app](https://sheetai.app/) - AI-powered tool to quickly generate formulas for Google Sheets. `#freemium`


### PR DESCRIPTION
## Description

Adds ParlayAPI MCP to Data & BI using the documented README contribution route. I maintain this public Python stdio server for sports odds, player props, public event discovery and account usage. The entry states that account data tools use each user's own key and allowances.

## Type of Change
- [x] Tool Submission

## Checklist
- [x] Entry follows the contribution format and is alphabetized
- [x] Self-reviewed the one-line change
- [x] No code changes requiring comments

No duplicate was found in current source or issues/PRs. Source link resolves; `git diff --check` passes. Published package initialization and 22-tool discovery were already verified without account calls. Full frontend checks were not run for this README-only addition. This does not claim native-client testing or automatic live-site publication.
