### PR TITLE
feat: Add LumiYing to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,8 @@ Use these hashtags in search to filter out the tools
 - [LTX Studio](https://ltx.studio/) - Film production platform for story control. `#free`
 - [Luma AI](https://lumalabs.ai/) - AI-powered 3D capture and video generation from text prompts. `#freemium`
 - [Luma Dream Machine](https://lumalabs.ai/dream-machine) - Advanced AI video generation with cinematic quality `#freemium`
+- [LumiYing](https://lumiying.com/) - Generates videos and images from text and visual references using multiple AI models in one workspace. `#paid`
+
 - [Medeo](https://medeo.ai/) - Integrates ChatGPT, Kling, and ElevenLabs. `#freemium`
 - [MetaMirror](https://metamirror.io/) - transforms scripts into videos viaSymbiosis engine. `#paid`
 - [Moonvalley](https://moonvalley.ai/) - AI-powered video generation with advanced editing capabilities `#freemium`


### PR DESCRIPTION
## Description

Adds LumiYing to the Video category. It is a web platform for generating videos and images with multiple AI models, including text-to-video and image-to-video workflows.

I’m affiliated with LumiYing. The entry links directly to the product homepage and uses the paid tag because generation consumes purchased credits.

## Type of Change
- [x] Tool Submission

## Checklist
- [x] The entry follows the listing format and is alphabetized within Video.
- [x] I have reviewed the diff, product URL, and pricing tag.

README listing only; no application code changed.
