### PR TITLE
feat: Add Altyst to Real Estate

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ Use these hashtags in search to filter out the tools
 - [Durable](https://durable.co/) - Build a website in 30 seconds with AI, leveraging AI-powered design and marketing tools to boost traffic and increase revenue. `#freemium`
 - [HoopsAI](https://www.hoopsai.com/) - Offers real-time trading insights and analysis for retail investors. `#free`
 - [Koyfin](https://www.koyfin.com/) - AI-powered financial data and visualization platform that provides advanced charting, analytics, and market dashboards. `#freemium`
-- [SwiftAlerts](https://swiftalerts.trade/) - Connect Claude, Codex, Cursor, and other AI assistants to structured market intelligence. `#paid` `#finance` `#analytics`
+- [SwiftAlerts](https://swiftalerts.trade/) - Connect Claude, Codex, Cursor, and other AI assistants to structured market intelligence. `#paid`
 - [Uptrends.ai](https://uptrends.ai/) - The first AI stock market news monitoring platform made for DIY investors. Uptrends.ai analyzes chatter to help you find the trends & events that matter. `#paid`
 
 **[⬆️ Back to Top](#table-of-contents)**
@@ -1010,7 +1010,7 @@ Use these hashtags in search to filter out the tools
 
 ## Real Estate
 
-- [Altyst](https://altyst.ai/) - Turns a commercial property's address, listing link, or offering memorandum into a full editable underwriting model with cash flows, IRR, and DSCR. `#paid` `#finance`
+- [Altyst](https://altyst.ai/) - Turns a commercial property's address, listing link, or offering memorandum into a full editable underwriting model with cash flows, IRR, and DSCR. `#paid`
 - [HomeByte](https://homebyte.com/) - Find your dream home with the most advanced home search on the planet. `#free`
 - [IACrea](https://iacrea.com/) - AI-powered Home Staging Solution `#paid`
 - [InteriorAI](https://interiorai.com/) - Interior design ideas using Artificial Intelligence `#paid`

--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,7 @@ Use these hashtags in search to filter out the tools
 
 ## Real Estate
 
+- [Altyst](https://altyst.ai/) - Turns a commercial property's address, listing link, or offering memorandum into a full editable underwriting model with cash flows, IRR, and DSCR. `#paid` `#finance`
 - [HomeByte](https://homebyte.com/) - Find your dream home with the most advanced home search on the planet. `#free`
 - [IACrea](https://iacrea.com/) - AI-powered Home Staging Solution `#paid`
 - [InteriorAI](https://interiorai.com/) - Interior design ideas using Artificial Intelligence `#paid`


### PR DESCRIPTION
Adds one tool to **Real Estate**, alphabetically first in that section.

**What it does.** Altyst underwrites commercial real estate. Paste an address or a listing link, or upload an offering memorandum, rent roll or T-12 operating statement, and it reads the documents and produces a full editable financial model: monthly and annual cash flows, unlevered and levered IRR, equity multiple, DSCR, debt yield, waterfall distributions, exit valuation and two-way sensitivity tables. It covers multifamily, hotel, office, medical office, retail, industrial, flex, mixed-use, self-storage, land and ground-up development, and exports to an Excel workbook, IC memo PDF, deck, PPTX, lender package or offering summary.

**Why this category.** The Real Estate section is currently mostly listing, staging and copywriting tools; this is the analysis side — the AI reads the deal documents rather than generating marketing images.

**Against CONTRIBUTING.md:**
- Format is `- [Tool Name](url) - One-sentence description. \`#tag\``, with a direct product link (not an article).
- Alphabetical placement within the category.
- Tags: `#paid` (there is no free tier and no free trial; pricing is public at https://altyst.ai/pricing) and `#finance` for filtering.
- Not already listed — searched the README for "Altyst" and for "underwriting".

I used the PR path rather than https://collectiveai.tools/submit because I could not complete the web form from this environment. Happy to resubmit through the form instead if you would rather have it go straight into the database.

**Disclosure:** I work on Altyst.