### PR TITLE
docs: add 10xhuman to Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ Use these hashtags in search to filter out the tools
 
 ## Education
 
+- [10xhuman](https://10xhuman.net/?lang=en) - AI-guided project learning in Korean, English and Japanese, with a free project brief and downloadable workbook to get started. `#education`
 - [AI University Hall](https://www.aidaxue.com/) - iFlytek programming and AI training platform. `#free`
 - [Alibaba Cloud Path](https://www.alibabagroup.com/) - 871 class hours and 26 free courses. `#free`
 - [ClassPoint AI](https://www.classpoint.io/) - AI tool for teachers to generate questions out of any PowerPoint slide. `#free`


### PR DESCRIPTION
## Description

Submitting 10xhuman on behalf of the project, with AI assistance. Adds one alphabetized entry under Education: a web-based AI-guided project learning service with Korean, English and Japanese interfaces. The free starting point is a no-signup project brief and downloadable workbook; the brief itself formats user input without AI generation. Full learning access has separate website terms, so this entry does not label the entire service free or advertise a recurring subscription.

Public starting point: https://10xhuman.net/start?lang=en
Public workbook: https://github.com/fractalreason-coder/10xhuman-project-workbook

## Type of Change
- [x] Tool Submission

## Validation
- Read the contribution guidelines and code of conduct.
- One README entry only, first in the Education category, with a direct tool URL and an education tag.
- Reviewed the free brief, download and three-language interfaces during live service QA; no claim of learner outcomes or certification.
- `git diff --check` passes. No executable changes; application tests were not run for this listing-only contribution.
