### PR TITLE
feat: Add LiveFaceSwap AI to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,6 +1171,7 @@ Use these hashtags in search to filter out the tools
 - [JiMeng AI](https://jimeng.jianying.com/) - 2K high-definition art and shot generation. `#freemium`
 - [Kling AI Video](https://kling.kuaishou.com/) - High-quality video generation with realistic motion and physics `#freemium`
 - [LensGo](https://lensgo.ai/) - character style transfer tool (Shutdown 2025). `#free`
+- [LiveFaceSwap AI](https://livefaceswap.ai/) - Cloud-based live webcam transformations with face, outfit, and style references plus desktop virtual-camera output. `#paid` `#video`
 - [LTX Studio](https://ltx.studio/) - Film production platform for story control. `#free`
 - [Luma AI](https://lumalabs.ai/) - AI-powered 3D capture and video generation from text prompts. `#freemium`
 - [Luma Dream Machine](https://lumalabs.ai/dream-machine) - Advanced AI video generation with cinematic quality `#freemium`


### PR DESCRIPTION
## Description
Adds [LiveFaceSwap AI](https://livefaceswap.ai/) to Video between LensGo and LTX Studio. It brings a reference-driven live webcam workflow to the catalog, with desktop virtual-camera output for compatible streaming and calling software.

The entry uses paid/video tags: signup trial credits are available, but continued cloud AI use consumes paid credits and needs internet access. Submitted on behalf of the LiveFaceSwap product team.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Tool Submission
- [ ] Other

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

Only a README listing changes; code-specific tests and comments are not applicable. The official product page and contribution guidelines were checked, and no existing LiveFaceSwap entry or suggestion was found.

