### PR TITLE
feat: Add YYLO to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ Use these hashtags in search to filter out the tools
 - [Windsurf](https://codeium.com/windsurf) - AI-powered IDE with built-in code generation and chat `#freemium`
 - [Windsurf (Codeium)](https://codeium.com/windsurf)%20AI%20Tool) - Multi-step collaborative Cascade technology. `#free`
 - [YingTu](https://yingtu.ai/en) - Browser playground for testing AI image and video API routes, prompts, reference inputs, task status, and downloads before integration. `#free`
+- [YYLO](https://github.com/yylo-dev/yylo) - Open-source command-line orchestrator for coding agents like Pi and Codex, with typed task, validation, merge, and release-readiness boundaries across isolated git worktrees. `#free` `#opensource`
 - [OutboundGateway](https://outboundgateway.com/) - Static outbound IPs for AI agents and MCP servers. `#paid`
 
 **[⬆️ Back to Top](#table-of-contents)**


### PR DESCRIPTION
## Description

Adds YYLO to the Developer Tools category as one alphabetized, direct tool entry.

YYLO is an open-source (MIT) command-line orchestrator for coding agents: it drives typed task, validation, merge, and release-readiness boundaries across isolated git worktrees, with subagent engines like Pi and Codex, a risk-based merge queue, and receipt-backed repository changes. Install via npm (`@yylo/cli`); active daily development since January 2026.

Direct tool URL: https://github.com/yylo-dev/yylo

Disclosure: I'm part of the YYLO team; this PR was prepared with AI-agent assistance and follows the repository's one-line tool format.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Tool Submission
- [ ] Other

## Checklist

- [x] My change follows the repository's one-line tool format and alphabetical placement
- [x] I have performed a self-review of the change
- [x] The direct tool URL returns HTTP 200
- [x] I searched the README and open pull requests for duplicates

No code or hard-to-understand logic is changed, so code comments are not applicable.

By submitting this pull request, I confirm that I have read and agree to abide by the Code of Conduct and Contributing Guidelines.