### PR TITLE
feat: Add Vivify GPT Image 2.5 to Image Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,7 @@ Use these hashtags in search to filter out the tools
 - [Stable Diffusion Online](https://stablediffusionweb.com/#ai-image-generator) - text-to-image diffusion model capable of generating photo-realistic images given any text input, cultivates autonomous freedom to produce incredible imagery, empowers billions of people to create stunning art within seconds. `#opensource`
 - [stockimg.ai](https://stockimg.ai/) - Stockimg is an all in one design and content creation tool powered by AI. You can easily generate logo, illustration, wallpaper, poster and more. `#freemium`
 - [Top VS Best](https://topvsbest.com/aiimagecreator/) - Effortlessly craft mesmerizing and exclusive images through our AI-powered image generation. `#free`
+- [Vivify GPT Image 2.5](https://vivify.video/models/gpt-image-2-5) - Generate product visuals and edit reference images with Flare or Sunburst in a browser. `#paid` `#design`
 - [Wepik AI](https://wepik.com/ai) - Text to Image Converter `#free`
 - [Seedream AI Studio](https://seedream4.video/) - Multi-model AI image generation using ByteDance Seedream 5.0/4.5/4.0, with one-click image-to-video animation via Kling 2.1. `#freemium`
 


### PR DESCRIPTION
Adds a browser-based image generation and reference-editing tool to Image Generator. The linked page is the tool itself, with model controls, reusable example prompts, and credit quotes before generation. The entry uses paid/design tags and is placed alphabetically.

Disclosure: submitted on behalf of the Vivify product team, with AI assistance. Vivify is a third-party application; image generation requires an account and usage credits. The public generator page and example outputs were checked.