### PR TITLE
feat: Add StudyArena to Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ Use these hashtags in search to filter out the tools
 - [Sibyl AI](https://sibyls.ai/) - Provide guidance, insights, and support for individuals at different levels of spiritual exploration, from neophytes to adepts and holistic practitioners. `#paid`
 - [SlidesAI.io](https://www.slidesai.io/) - powerful AI tool that can help teachers create visually appealing and engaging presentations for their classroom teaching instantly. `#freemium`
 - [SocratiQ](https://socratiq.ai/) - The Future of Education, Integrated `#paid`
+- [StudyArena](https://studyarena.com) - Students compare three AI explanations for free, vote before seeing model names, then reveal which models answered. `#freemium` `#education`
 - [Tencent Coding](https://www.tencent.com/) - Popularization platform for master skills. 148 `#free`
 - [Text With Authors](https://textwith.me/authors/) - Chat with famous authors, poets, playwrights, philosophers and more from classical literature. `#freemium`
 - [Text With History](https://textwith.me/history/) - Chat with famous politicians, scientists, artists, world leaders and more. Also includes history tutors. `#freemium`


### PR DESCRIPTION
## Description

I'm one of the people building StudyArena. I'd like to add it to Education because comparing explanations before seeing the model names gives students another way to work through a study question.

The three-answer comparison, vote and reveal are free. I used `#freemium` because model choice and six-model comparisons are paid, and placed the entry between SocratiQ and Tencent Coding. The canonical link and duplicate searches across files and open and closed submissions are checked.

## Type of Change
- [x] Tool Submission

## Checklist
- [x] The entry follows the contribution format and alphabetical order.
- [x] I reviewed the one-entry diff and its link.
- [x] I read the contribution guidelines and code of conduct.

## Validation
`pnpm type-check` and all 136 tests pass; `pnpm build` also passes with existing warnings. On the unchanged upstream checkout, `pnpm lint:check` reports 20 existing errors and 78 warnings in application code. This PR only adds the README entry.
