### PR TITLE
docs: add C2Anime to Video tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ Use these hashtags in search to filter out the tools
 ## Video
 
 - [AVCLabs](https://www.avclabs.com/) - 100% free automatic video background remover. `#free`
+- [C2Anime](https://c2anime.com/) - AI Anime Agent that turns stories into animated short films with voices and sound. `#paid` `#animation`
 - [Captions](https://www.captions.ai/) - AI creative studio application for creators. `#freemium`
 - [Chromox](https://chromox.alkaidvision.com/) - Transforming Ideas into Visual Stories. `#free`
 - [Clipfly](https://www.clipfly.com/) - Integrated video generation and enhancement. `#freemium`


### PR DESCRIPTION
Adds C2Anime to the Video category: an AI Anime Agent for turning stories into animated short films with voices and sound. The entry uses the official website URL and is placed alphabetically before Captions.

Affiliation: submitted on behalf of C2Anime. Video creation uses paid credits, so the listing is tagged `#paid`; sample films are free to watch.

Validation: checked for an existing C2Anime entry and PR; this change adds one directory entry only.
