### PR TITLE
Add OrcaReplay to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ Use these hashtags in search to filter out the tools
 - [Ollama](https://ollama.com/) - Run LLMs locally with GPU acceleration. Llama, Mistral, DeepSeek, Gemma and more. `#free` `#opensource`
 - [n8n](https://n8n.io/) - Open-source workflow automation with AI agent nodes, MCP support, and 400+ integrations. `#freemium` `#opensource`
 - [OpenCode](https://github.com/anomalyco/opencode) - Open-source terminal AI coding agent with skills, MCP, and custom workflows. `#free` `#opensource`
+- [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) - Records a coding-agent run and replays it back to the agent with no model called, or forks a checkpoint onto other models to compare. `#free`
 - [Plandex](https://plandex.ai/) - Terminal AI agent for large-scale projects. `#free`
 - [QueryCraft](https://querycraft.ai/) - AI-Powered Data Query Generator `#free`
 - [Quest AI](https://www.quest.ai/) - Intelligent Q&A and info retrieval for dev. `#freemium`


### PR DESCRIPTION
Adds OrcaReplay to **Developer Tools**, right after `OpenCode` — the closest neighbour in the section, and the distinction between them is the point of the entry.

I used the PR path rather than [collectiveai.tools/submit](https://collectiveai.tools/submit) because CONTRIBUTING says PRs are still taken for `README.md`. Say the word if you would rather I went through the form instead and I will close this.

**Disclosure: I work on it.** Apache-2.0, `#free`, no paid tier — tag chosen accordingly.

## What it is

`OpenCode`, `Aider` and `Agent Island` in this section *are* coding agents. This is the layer underneath: a local proxy that records one and plays the recording back, so the same session runs again with no provider called and no tokens spent.

```console
$ orca record claude -- -p "fix the failing test"
$ orca replay last
info replaying exchanges=8 egress=blocked
info replay.done reused=8/8 exact=8 divergences=0 exit=0
```

It is useless without an agent to point at, which is why it sits beside them rather than competing.

Nothing is installed into the agent — no plugin, no SDK — so one tool covers Claude Code, Codex, goose, OpenCode, Cursor, CrewAI and OpenHands. From a checkpoint a run can also continue **live** on a different model, with `--verify "npm test"` making the exit code the verdict.

`Ollama` is two lines above, which is worth noting: I verified this against Ollama specifically — recorded a run on a local model, killed the server, replayed clean with nothing listening on 11434.

## One scope note

"Offline" means **no model provider is called**. Replay still executes recorded tool calls for real, so a recorded `curl` reaches the network. It is not a sandbox, and the README says so.
