### PR TITLE
Add AI Image to Image Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ Use these hashtags in search to filter out the tools
 
 - [Alimvo](https://alimvo.com/) - AI product photo and video generator for ecommerce brands. Create studio shots, lifestyle scenes, and ad creatives in minutes. `#freemium`
 - [Adobe Firefly 3](https://www.adobe.com/products/firefly.html) - Adobe's latest AI image generation with commercial-safe content `#freemium`
+- [AI Image](https://aiimage.com) - Generate and edit images from text prompts and reference pictures in a browser. `#paid` `#design`
 - [AI Passport Photo](https://aipassportphoto.com/) - Take A Photo with Your Mobile Phone and Get Your Passport Photo in Seconds. `#freemium`
 - [Bing Image Creator](https://www.bing.com/images/create) - Image Creator from Microsoft Designer allows you to generate captivating images based on your words using AI. `#freemium`
 - [DALL-E 3](https://openai.com/dall-e-3) - OpenAI's latest image generation model with improved quality and safety `#freemium`


### PR DESCRIPTION
## Description
Add [AI Image](https://aiimage.com) to **Image Generator**. It is a hosted image generation and editing tool with text prompts and reference-image workflows.

## Validation
- Checked the existing list for duplicate homepage links.
- Preserved the category format and included only this tool.
- Reviewed the public product information and verified the homepage is reachable (HTTP 200).
- Documentation-only change; no application code or generated images are included.

## Disclosure
I am affiliated with AI Image. This submission was prepared with AI assistance. The product offers starter trial credits and paid plans; the entry does not claim unlimited free use.

## Type of Change
- [x] Documentation update
- [x] Tool Submission

The entry is placed before AI Passport Photo and includes pricing/design tags. Application code checks were not run because only the Markdown tool list changed.
